### PR TITLE
Serve blog via Worker routes (fix apex 409)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,9 +6,11 @@
     "directory": "./dist",
     "not_found_handling": "404-page"
   },
+  "workers_dev": true,
+  "preview_urls": true,
   "routes": [
-    { "pattern": "wibrow.dev", "custom_domain": true },
-    { "pattern": "samuel.wibrow.dev", "custom_domain": true }
+    { "pattern": "wibrow.dev/*", "zone_name": "wibrow.dev" },
+    { "pattern": "samuel.wibrow.dev/*", "zone_name": "wibrow.dev" }
   ],
   "observability": {
     "enabled": true


### PR DESCRIPTION
Follow-up to #53. The `custom_domain` attach failed with a 409 because `wibrow.dev` (→ cluster tunnel) and `samuel.wibrow.dev` (→ old Pages project) already have proxied DNS records.

**Fix:** use Worker **route patterns** instead of custom domains. Routes ride on the existing proxied records and intercept at Cloudflare's edge — no DNS changes, no Pages detach, no downtime. Also re-enable `workers_dev` + `preview_urls` (a routed deploy disables them by default, which had broken the `*.workers.dev` URL and PR preview URLs).

Already deployed and verified live: `wibrow.dev` and `samuel.wibrow.dev` both serve the blog (200, security headers from `_headers`, proper 404s). Merging keeps CI in sync with the live routes.