### PR TITLE
ci: alias PR preview deployments to the PR number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,18 +50,24 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          # PRs upload a preview version aliased to the PR number, so repeated
-          # pushes reuse the same preview URL instead of minting a new one
-          # each time (Cloudflare has no API to delete old versions, so this
-          # just slows the buildup rather than cleaning it up). Main deploys live.
+          # PRs upload a preview version tagged with a stable alias
+          # (pr-<number>), giving a fixed preview URL that always points at
+          # the latest push. Cloudflare has no API to delete old versions —
+          # each push still creates a new version under the hood — but the
+          # alias means reviewers get one evergreen link instead of a new URL
+          # every commit. Main deploys live.
           command: ${{ github.event_name == 'pull_request' && format('versions upload --preview-alias pr-{0}', github.event.number) || 'deploy' }}
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          WRANGLER_OUTPUT: ${{ steps.deploy.outputs.command-output }}
         with:
           script: |
-            const url = "${{ steps.deploy.outputs.deployment-url }}";
+            const aliasMatch = (process.env.WRANGLER_OUTPUT || "").match(/Version Preview Alias URL:\s*(\S+)/);
+            const url = aliasMatch ? aliasMatch[1] : process.env.DEPLOYMENT_URL;
             if (!url) return;
             const body = `🚀 **Preview deployed**: ${url}`;
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          # PRs upload a preview version (no production traffic); main deploys live.
-          command: ${{ github.event_name == 'pull_request' && 'versions upload' || 'deploy' }}
+          # PRs upload a preview version aliased to the PR number, so repeated
+          # pushes reuse the same preview URL instead of minting a new one
+          # each time (Cloudflare has no API to delete old versions, so this
+          # just slows the buildup rather than cleaning it up). Main deploys live.
+          command: ${{ github.event_name == 'pull_request' && format('versions upload --preview-alias pr-{0}', github.event.number) || 'deploy' }}
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Add `--preview-alias pr-<number>` to the PR deploy command so repeated pushes to the same PR reuse one stable preview URL instead of minting a new Worker version (and URL) on every commit.

## Context
Cloudflare doesn't expose an API or CLI to delete individual Worker versions (confirmed against the Workers Scripts Versions API and the beta Workers Versions API — both are list/get/create only, no delete), so this can't clean up existing orphaned preview versions, and merging/closing a PR still won't trigger any deletion. This just slows the rate new ones pile up.

## Test plan
- [ ] Open this PR itself and confirm the "Preview deployed" comment still posts with a working URL
- [ ] Push a second commit to this branch and confirm the preview URL is reused rather than replaced with a new one